### PR TITLE
Fixes for CHEF-3647: changing a user's password in chef-server-webui changes their public key to undefined

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,6 +115,7 @@ class User
     # a PUT with private_key = true tells Erchef to regen the keypair
     # https://github.com/opscode/chef_wm/blob/master/src/chef_wm_named_user.erl#L123-136
     result['private_key'] = true if regenerate_private_key?
+    result['public_key'] = public_key unless public_key.blank?
     result.to_json(*a)
   end
 


### PR DESCRIPTION
This fixes: http://tickets.opscode.com/browse/CHEF-3647
