### PR TITLE
[CHEF-3654] properly redirect to node show 

### DIFF
--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -83,7 +83,7 @@ class NodesController < ApplicationController
       @node.normal_attrs = Chef::JSONCompat.from_json(params[:attributes])
       @node.run_list.reset!(params[:for_node] ? params[:for_node] : [])
       client_with_actor.post("nodes", @node)
-      redirect_to :nodes, :notice => "Created Node #{@node.name}"
+      redirect_to node_url(@node.name), :notice => "Created Node #{@node.name}"
     rescue => e
       log_and_flash_exception(e,
         "Exception raised creating node, #{e.message.length <= 150 ? e.message : "please check logs for details"}")
@@ -103,8 +103,7 @@ class NodesController < ApplicationController
       @node.run_list.reset!(params[:for_node] ? params[:for_node] : [])
       @node.normal_attrs = Chef::JSONCompat.from_json(params[:attributes])
       @node = client_with_actor.put("nodes/#{params[:id]}", @node)
-      flash.now[:notice] = "Updated Node"
-      render :show
+      redirect_to node_url(@node.name), :notice => "Updated Node #{@node.name}"
     rescue => e
       log_and_flash_exception(e,
         "Exception raised updating node, #{e.message.length <= 150 ? e.message : "please check logs for details"}")


### PR DESCRIPTION
We need to use a `redirect_to` (vs a `render`) so the NodesController's 
show method is called. This will ensure the `@recipes` instance variable 
is set (which the show view requires).

fix for:
http://tickets.opscode.com/browse/CHEF-3654
