### PR TITLE
update rails to at least 3.2.11

### DIFF
--- a/chef-server-webui.gemspec
+++ b/chef-server-webui.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://wiki.opscode.com/display/chef"
 
   s.add_dependency "chef"
-  s.add_dependency "rails", "3.2.2"
+  s.add_dependency "rails", "~> 3.2.11"
   s.add_dependency "jquery-rails"
   s.add_dependency "haml-rails"
   s.add_dependency "coderay"


### PR DESCRIPTION
Update includes patch fixes for CVEs disclosed january 2013.

See also:
http://weblog.rubyonrails.org/2013/1/8/Rails-3-2-11-3-1-10-3-0-19-and-2-3-15-have-been-released/
