### PR TITLE
Status Page Node Limit and Filtering

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -41,9 +41,26 @@ class StatusController < ApplicationController
 
   def generate_status_hash(query)
     result = Hash.new
-    client_with_actor.get("search/node?q=*:*&sort=&start=0&rows=20")["rows"].each do |n|
-      result[n.name] = n unless n.nil?
+
+    query = (query.nil? || query.empty?) ? "*:*" : URI.escape(query, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+
+    args = {
+      'name' => [ 'name' ],
+      'platform'   => [ 'platform' ],
+      'platform_version' => [ 'platform_version' ],
+      'fqdn' => [ 'fqdn' ],
+      'ipaddress' => [ 'ipaddress' ],
+      'uptime' => [ 'uptime' ],
+      'ohai_time' => [ 'ohai_time' ],
+      'run_list' => [ 'run_list' ]
+    }
+
+    client_with_actor.post("search/node?q=#{query}&sort=&start=0", args)["rows"].each do |n| puts n.inspect
+
+    result[n['data']['name']] = n['data'] unless n.nil?
+
     end
+
     result
   end
 

--- a/app/views/status/index.html.haml
+++ b/app/views/status/index.html.haml
@@ -19,7 +19,7 @@
           - else
             - @status.sort.each_with_index do |node, index|
               %tr{:class => "#{index % 2 == 1 ? 'odd' : 'even'}"}
-                %td= link_to(node[1].name, node_path(node[1].name))
+                %td= link_to(node[1]['name'], node_path(node[1]['name']))
                 %td= "#{node[1]["platform"]} #{node[1]["platform_version"]}"
                 %td= node[1]["fqdn"]
                 %td= node[1]["ipaddress"]
@@ -47,7 +47,7 @@
                         .tooltip #{date.to_formatted_s(:long)} UTC
                 - else
                   %td Not Checked In
-                - unless node[1].run_list.nil?
+                - unless node[1]['run_list'].nil?
                   %td
                     .accordion
                       = link_to("Run List", "#", :class => 'tooltip')
@@ -60,13 +60,13 @@
                               %th Version
                               %th.last Type
                           %tbody
-                            - if node[1].run_list.empty?
+                            - if node[1]['run_list'].empty?
                               %tr
                                 %td{:colspan => 2} This node has no roles or recipes applied.
                             - else
-                              -node[1].run_list.each_with_index do |run_list_item, i|
+                              -node[1]['run_list'].each_with_index do |run_list_item, i|
                                 %tr
                                   %td.position= i
-                                  %td= run_list_item.name
-                                  %td= run_list_item.version
-                                  %td= run_list_item.type
+                                  %td = run_list_item
+
+


### PR DESCRIPTION
To address CHEF-4306  - removed 20 node limit on status page, and added missing code needed to support filtering status page by environment
