### PR TITLE
Stop json being escaped as html

### DIFF
--- a/app/views/environments/_form.html.erb
+++ b/app/views/environments/_form.html.erb
@@ -85,6 +85,6 @@
 
 <script type='text/javascript'>
   function cookbook_versions() {
-    return <%= cookbook_version_constraints.to_json %>;
+    return <%= cookbook_version_constraints.to_json.html_safe %>;
   }
 </script>


### PR DESCRIPTION
-This is causing the environment edit screen to only partially load with all cookbooks cleared from the environment
