### PR TITLE
Fix environment filter not working on status page

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -41,7 +41,7 @@ class StatusController < ApplicationController
 
   def generate_status_hash(query)
     result = Hash.new
-    client_with_actor.get("search/node?q=*:*&sort=&start=0&rows=20")["rows"].each do |n|
+    client_with_actor.get("search/node?q="+query+"&sort=&start=0&rows=20")["rows"].each do |n|
       result[n.name] = n unless n.nil?
     end
     result


### PR DESCRIPTION
-Query parameter for generate_status_hash was being ignored
