### PR TITLE
Fix for CHEF-4345

### DIFF
--- a/app/views/nodes/_form.html.erb
+++ b/app/views/nodes/_form.html.erb
@@ -10,7 +10,9 @@
 
     <div>
       <label class="label" for="nodeEnvironment">Environment:</label>
-      <%= select_tag :chef_environment, options_from_collection_for_select(@environments, :to_s, :to_s, @env), :id => 'nodeEnvironment' %>
+      <select name="chef_environment" id="nodeEnvironment">
+      <%= options_for_select(@environments, @env) %>
+      </select>
       <br />
       <span class="description">The node's environment</span>
     </div>


### PR DESCRIPTION
The select_tag syntax is adding selected=selected to the select tag itself and not the option. This change uses the options_for_select() method and properly selected the nodes environment.
