### PR TITLE
[CHEF-2060] set autocomplete attribute for login form to "off".

### DIFF
--- a/app/views/users/login.html.haml
+++ b/app/views/users/login.html.haml
@@ -12,7 +12,7 @@
     .inner
   .content
     .inner
-      = form_tag login_exec_users_url, :method => :post, :id => 'login', :class => 'form' do
+      = form_tag login_exec_users_url, :method => :post, :id => 'login', :class => 'form', :autocomplete => "off" do
         %div.group.form
           %p= label_tag :name, "Username", :class => "label"
           %p= text_field_tag "name", params.has_key?(:name) ? h(params[:name]) : @user.name


### PR DESCRIPTION
RE: http://rapi7.com/db/vulnerabilities/spider-sensitive-form-data-autocomplete-enabled
