### PR TITLE
[CHEF-4859] Support rendering non-ascii characters in cookbook files

### DIFF
--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -204,7 +204,7 @@ class CookbooksController < ApplicationController
       logger.debug("fetching file from '#{file_url}' for highlighting")
 
       file = client_with_actor.get(file_url)
-      tokens = CodeRay.scan(file, lang)
+      tokens = CodeRay.scan(file.force_encoding('utf-8'), lang)
       highlighted_file = CodeRay.encode_tokens(tokens, :span)
       highlighted_file.html_safe
     else


### PR DESCRIPTION
This patch sets the default encoding from US-ASCII to UTF-8.
https://tickets.opscode.com/browse/CHEF-4859
