### PR TITLE
add autocomplete=off to all password fields

### DIFF
--- a/app/assets/javascripts/chef.js
+++ b/app/assets/javascripts/chef.js
@@ -104,13 +104,16 @@ $(document).ready(function(){
     var form = $(this);
     if (form.attr('id') === 'edit_user') {
       form.append('<input type="hidden" name="_method" value="put">');
-      form.append($('input#user_new_password')).css('display', 'none');
+      form.append($('input#user_new_password')).css('display', 'none').
+        attr('autocomplete', 'off');
       form.append($('input#user_admin')).css('display', 'none');
-      form.append($('input#user_confirm_new_password')).css('display', 'none');
+      form.append($('input#user_confirm_new_password')).css('display', 'none').
+        attr('autocomplete', 'off');
     }
     if (form.attr('id') === 'login') {
       form.append($('input#user_name')).css('display', 'none');
-      form.append($('input#password')).css('display', 'none');
+      form.append($('input#password')).css('display', 'none').
+        attr('autocomplete', 'off');
     }
   });
 

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -10,12 +10,18 @@
       = f.hidden_field :name
       %div.group.form
         %p= f.label :password, :class => "label"
-        %p= f.password_field :password, :id => "user_new_password", :class => "password_field"
+        %p= f.password_field :password,
+          :autocomplete => 'off',
+          :class        => 'password_field',
+          :id           => 'user_new_password'
         %span.description New password for the User. Keep blank if you do not want to change password.
 
       %div.group.form
         %p= f.label :password_confirmation, :class => "label"
-        %p= f.password_field :password_confirmation, :id => "user_confirm_new_password", :class =>"password_field"
+        %p= f.password_field :password_confirmation,
+          :autocomplete => 'off',
+          :class        => 'password_field',
+          :id           => 'user_confirm_new_password'
         %span.description Confirm new password for the User. Keep blank if you do not want to change password.
 
       %div.group.form

--- a/app/views/users/login.html.haml
+++ b/app/views/users/login.html.haml
@@ -19,7 +19,9 @@
 
         %div.group.form
           %p= label_tag :password, nil, :class => "label"
-          %p= password_field_tag "password", "", :class => "password_field"
+          %p= password_field_tag "password", "",
+            :autocomplete => 'off',
+            :class        => 'password_field',
 
         %div.group.form
           .actions-bar

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -12,11 +12,17 @@
 
         %div.group.form
           %p= f.label :password, :class => "label"
-          %p= f.password_field :password, :id => "user_new_password", :class => "password_field"
+          %p= f.password_field :password,
+            :autocomplete => 'off',
+            :class        => 'password_field',
+            :id           => 'user_new_password'
 
         %div.group.form
           %p= f.label :password_confirmation, :class => "label"
-          %p= f.password_field :password_confirmation, :id => "user_confirm_new_password", :class =>"password_field"
+          %p= f.password_field :password_confirmation,
+            :autocomplete => 'off',
+            :class        => 'password_field',
+            :id           => 'user_confirm_new_password'
 
         %div.group
           %p= f.label :admin, :class => "label"


### PR DESCRIPTION
Fixes opscode/chef#1761.

Note that according to [OWASP](https://www.owasp.org/index.php/Testing_for_Vulnerable_Remember_Password_%28OWASP-AT-006%29#Summary):

> Since early 2014 most major browsers will override any use of autocomplete="off" with regards to password forms and as a result previous checks for this are not required and recommendations should not commonly be given for disabling this feature.

But we'll add it anyway.
